### PR TITLE
docs: add issue updates for new features

### DIFF
--- a/.github/issue-updates/2b3b9706-d40c-4bb5-b582-922218c44154.json
+++ b/.github/issue-updates/2b3b9706-d40c-4bb5-b582-922218c44154.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Implement GitHub App version",
+  "body": "Develop a GitHub App variant of the action for granular permissions and easier installation. Include authentication setup, deployment instructions, and update workflows.",
+  "labels": ["enhancement", "codex"],
+  "guid": "d70a135a-80fc-4881-a846-4bf2ea1456ce",
+  "legacy_guid": "create-implement-github-app-version-2025-06-29"
+}

--- a/.github/issue-updates/30021e50-320b-4d6b-8377-1268ecb0d4e7.json
+++ b/.github/issue-updates/30021e50-320b-4d6b-8377-1268ecb0d4e7.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Add Dockerfile linting and formatting",
+  "body": "Integrate hadolint and dockerfile formatting using shfmt or dockfmt. Update action.yml to include Dockerfile in languages. Document usage in README and add tests.",
+  "labels": ["enhancement", "codex"],
+  "guid": "51125d49-6770-4947-9ff1-e6c213a3a3b0",
+  "legacy_guid": "create-add-dockerfile-linting-and-formatting-2025-06-29"
+}

--- a/.github/issue-updates/7d1d97bb-9c3c-4b49-803b-0f939fa68e01.json
+++ b/.github/issue-updates/7d1d97bb-9c3c-4b49-803b-0f939fa68e01.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Add Terraform formatting support",
+  "body": "Use 'terraform fmt' for .tf files. Update action.yml to include terraform language option, install terraform, and add examples and tests.",
+  "labels": ["enhancement", "codex"],
+  "guid": "c468aaa2-fbbc-4aab-9bd8-b4dd2d0c1f04",
+  "legacy_guid": "create-add-terraform-formatting-support-2025-06-29"
+}


### PR DESCRIPTION
## Description
Add three issue update files proposing enhancements for Dockerfile formatting, Terraform support, and a GitHub App version.

## Motivation
The repository currently lists these items as planned features in the changelog but no tracking issues exist. Creating issues helps schedule the work.

## Changes
- Add Dockerfile linting/formatting issue JSON
- Add Terraform formatting support issue JSON
- Add GitHub App version issue JSON

## Testing
- `git status` shows clean worktree

## Related Issues
None

------
https://chatgpt.com/codex/tasks/task_e_6861717340808321bcee7da8b812cf84